### PR TITLE
New interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,4 @@ SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 [compat]
 Combinatorics = "1"
 SIMD = "3"
-julia = "1.5"
+julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ For all other cases, the default choice is a `BenesNetwork{T}`.
 The backend can be chosen manually when constructing the permutation, for example
 
 ```julia 
-p = BitPermutation{UInt32}(v; backend=GRPNetwork)
+p = BitPermutation{UInt32}(GRPNetwork, v)
 ```
 
 Using intrinsics can be disabled by setting `ENV["BIT_PERMUTATIONS_USE_INTRINSICS"] = false` before loading the package or setting

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -3,7 +3,7 @@
 To gather the benchmarking data, run the following from the project root:
 
 ```
-julia --project=@. --threads=1 --optimize=3 --check-bounds=no benchmark/benchmarks.jl benchmark/data/results.json
+julia --project --threads=1 --optimize=3 --check-bounds=no benchmark/benchmarks.jl benchmark/data/results.json
 ```
 
 To plot the results, run

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -17,9 +17,9 @@ N = 10_000
 suite["Single"] = BenchmarkGroup()
 
 rand_perm(::Type{T}) where {T} = randperm(bitsize(T))
-benes_perm(::Type{T}) where {T} = BitPermutation{T}(randperm(bitsize(T)); backend=BenesNetwork)
-grp_perm(::Type{T}) where {T} = BitPermutation{T}(randperm(bitsize(T)); backend=GRPNetwork)
-avx_perm(::Type{T}) where {T} = BitPermutation{T}(randperm(bitsize(T)); backend=AVXCopyGather)
+benes_perm(::Type{T}) where {T} = BitPermutation{T}(BenesNetwork, randperm(bitsize(T)))
+grp_perm(::Type{T}) where {T} = BitPermutation{T}(GRPNetwork, randperm(bitsize(T)))
+avx_perm(::Type{T}) where {T} = BitPermutation{T}(AVXCopyGather, randperm(bitsize(T)))
 
 for T in test_types
     group = suite["Single"][T] = BenchmarkGroup()

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -330,12 +330,12 @@ end
 function AVXCopyGather{T}(perm::AbstractVector{Int}) where {T}
     n = length(perm)
     W = bitsize(T)
-    n ≤ bitsize(T) || throw(OverflowError("Permutation is too long for Type $T"))
+    n ≤ W || throw(OverflowError("Permutation is too long for Type $T"))
     isperm(perm) || throw(ArgumentError("Input vector is not a permutation"))
     USE_AVX512 || @warn "Not using AVX-512 instructions, performance may be limited" maxlog = 1
 
     # Pad permutation vector
-    perm = [collect(perm); (n + 1):bitsize(T)]
+    perm = [collect(perm); (n + 1):W]
 
     # Convert permutation to mask
     m = Vec{W,UInt8}(ntuple(i -> UInt8(perm[i] - 1), W))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,7 +115,7 @@ end
         p = randperm(n)
         p′ = collect(1:bitsize(T))
         p′[1:n] = p′[p]
-        backend = BenesNetwork{T}(p)
+        backend = @inferred BenesNetwork{T}(p)
         for _ in 1:100
             x = rand(T)
             @test bitstr(x)[p′] === bitstr(@inferred bitpermute(x, backend))
@@ -130,7 +130,7 @@ end
         p = randperm(n)
         p′ = collect(1:bitsize(T))
         p′[1:n] = p′[p]
-        backend = GRPNetwork{T}(p)
+        backend = @inferred GRPNetwork{T}(p)
         for _ in 1:100
             x = rand(T)
             @test bitstr(x)[p′] === bitstr(@inferred bitpermute(x, backend))
@@ -145,7 +145,7 @@ end
         p = randperm(n)
         p′ = collect(1:bitsize(T))
         p′[1:n] = p′[p]
-        backend = AVXCopyGather{T}(p)
+        backend = @inferred AVXCopyGather{T}(p)
         for _ in 1:100
             x = rand(T)
             @test bitstr(x)[p′] === bitstr(@inferred bitpermute(x, backend))
@@ -157,8 +157,11 @@ end
 @testset "BitPermutation{$T}" for T in base_types
     p₀ = [2, 6, 5, 8, 4, 7, 1, 3]
 
+    # Make sure default backend is inferred
+    P = @inferred BitPermutation{T}(p₀)
+
     @testset "$B" for B in backend_types
-        P = BitPermutation{T}(B, p₀)
+        P = @inferred BitPermutation{T}(B, p₀)
 
         # Make sure printing returns something
         buf = IOBuffer()
@@ -195,7 +198,7 @@ end
         # Test permutations of arrays
         for _ in 1:10
             p = randperm(bitsize(T))
-            P = BitPermutation{T}(B, p)
+            P = @inferred BitPermutation{T}(B, p)
 
             arr = rand(T, 1000)
             arr_copy = copy(arr)
@@ -224,7 +227,7 @@ end
 @testset "BitPermutation{$T}" for T in custom_types
     p = randperm(bitsize(T))
     # Rearranging takes too long 
-    P = BitPermutation{T}(BenesNetwork, p; rearrange=false)
+    P = @inferred BitPermutation{T}(BenesNetwork, p; rearrange=false)
 
     for _ in 1:100
         x = rand(T)


### PR DESCRIPTION
Change the argument order in `BitPermutation`, such that the type of the backend is inferrable.