### PR TITLE
Avoid nesting of adjoint permutations

### DIFF
--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -151,6 +151,7 @@ struct AdjointBitPermutation{T,P<:AbstractBitPermutation{T}} <: AbstractBitPermu
 end
 
 Base.adjoint(perm::AbstractBitPermutation) = AdjointBitPermutation(perm)
+Base.adjoint(perm::AdjointBitPermutation) = perm.parent
 
 bitpermute(x::Number, P::AdjointBitPermutation) = invbitpermute(x, P.parent)
 invbitpermute(x::Number, P::AdjointBitPermutation) = bitpermute(x, P.parent)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,6 +180,9 @@ end
         # Test conversion to `Vector`
         @test Vector(P) == p₀ && Vector(P') == invperm(p₀)
 
+        # Test that adjoint is self-inverse
+        @test P == P''
+
         # Test random permutations
         for _ in 1:10
             p = randperm(bitsize(T))


### PR DESCRIPTION
Currently, calling adjoint on an AdjointBitPermutation gives a nested AdjointBitPermutation. This has compile time and run time implications, such as when calling `Vector(p)` which would calculate several nested inverses. This PR makes the adjoint of an AdjointBitPermutation return the parent.